### PR TITLE
add label to metrics

### DIFF
--- a/rekcurd/rekcurd_dashboard_servicer.py
+++ b/rekcurd/rekcurd_dashboard_servicer.py
@@ -188,12 +188,14 @@ class RekcurdDashboardServicer(rekcurd_pb2_grpc.RekcurdDashboardServicer):
             raise Exception(f'Error: Invalid evaluation result file path specified -> {result_path}')
 
         result, details = self.app.evaluate(self.app.get_eval_path(data_path))
+        label_ios = [self.get_io_by_type(l) for l in result.label]
         metrics = rekcurd_pb2.EvaluationMetrics(num=result.num,
                                                 accuracy=result.accuracy,
                                                 precision=result.precision,
                                                 recall=result.recall,
                                                 fvalue=result.fvalue,
-                                                option=result.option)
+                                                option=result.option,
+                                                label=label_ios)
 
         eval_result_path = self.app.get_eval_path(result_path)
         Path(eval_result_path).parent.mkdir(parents=True, exist_ok=True)
@@ -244,12 +246,14 @@ class RekcurdDashboardServicer(rekcurd_pb2_grpc.RekcurdDashboardServicer):
             result_details = pickle.load(f)
         with open(eval_result_path + self.EVALUATE_RESULT, 'rb') as f:
             result = pickle.load(f)
+        label_ios = [self.get_io_by_type(l) for l in result.label]
         metrics = rekcurd_pb2.EvaluationMetrics(num=result.num,
                                                 accuracy=result.accuracy,
                                                 precision=result.precision,
                                                 recall=result.recall,
                                                 fvalue=result.fvalue,
-                                                option=result.option)
+                                                option=result.option,
+                                                label=label_ios)
 
         detail_chunks = []
         detail_chunk = []

--- a/rekcurd/utils/__init__.py
+++ b/rekcurd/utils/__init__.py
@@ -72,7 +72,8 @@ class PredictResult:
 class EvaluateResult:
     def __init__(self, num: int = None, accuracy: float = None,
                  precision: List[float] = None, recall: List[float] = None,
-                 fvalue: List[float] = None, option: Dict[str, float] = {}):
+                 fvalue: List[float] = None, option: Dict[str, float] = {},
+                 label: List[PredictLabel] = None):
         if num is None:
             self.num = 0
             self.accuracy = 0.0
@@ -80,6 +81,7 @@ class EvaluateResult:
             self.recall = [0.0]
             self.fvalue = [0.0]
             self.option = {}
+            self.label = [0.0]
         else:
             self.num = num
             self.accuracy = accuracy
@@ -87,6 +89,7 @@ class EvaluateResult:
             self.recall = recall
             self.fvalue = fvalue
             self.option = option
+            self.label = label
 
 
 class EvaluateResultDetail(NamedTuple):

--- a/rekcurd/utils/__init__.py
+++ b/rekcurd/utils/__init__.py
@@ -70,26 +70,16 @@ class PredictResult:
 
 
 class EvaluateResult:
-    def __init__(self, num: int = None, accuracy: float = None,
-                 precision: List[float] = None, recall: List[float] = None,
-                 fvalue: List[float] = None, option: Dict[str, float] = {},
-                 label: List[PredictLabel] = None):
-        if num is None:
-            self.num = 0
-            self.accuracy = 0.0
-            self.precision = [0.0]
-            self.recall = [0.0]
-            self.fvalue = [0.0]
-            self.option = {}
-            self.label = [0.0]
-        else:
-            self.num = num
-            self.accuracy = accuracy
-            self.precision = precision
-            self.recall = recall
-            self.fvalue = fvalue
-            self.option = option
-            self.label = label
+    def __init__(self, num: int, accuracy: float, precision: List[float],
+                 recall: List[float], fvalue: List[float], label: List[PredictLabel],
+                 option: Dict[str, float] = {}):
+        self.num = num
+        self.accuracy = accuracy
+        self.precision = precision
+        self.recall = recall
+        self.fvalue = fvalue
+        self.label = label
+        self.option = option
 
 
 class EvaluateResultDetail(NamedTuple):

--- a/test/test_dashboard_servicer.py
+++ b/test/test_dashboard_servicer.py
@@ -1,5 +1,4 @@
 import unittest
-import sys
 import time
 from functools import wraps
 from unittest.mock import patch, Mock, mock_open
@@ -13,7 +12,7 @@ from . import app, system_logger
 
 
 target_service = rekcurd_pb2.DESCRIPTOR.services_by_name['RekcurdDashboard']
-eval_result = EvaluateResult(1, 0.8, [0.7], [0.6], [0.5], {'dummy': 0.4})
+eval_result = EvaluateResult(1, 0.8, [0.7], [0.6], [0.5], {'dummy': 0.4}, ['label1'])
 eval_result_details = [EvaluateResultDetail(PredictResult('pre_label', 0.9), False)]
 eval_detail = EvaluateDetail('input', 'label', eval_result_details[0])
 
@@ -147,7 +146,7 @@ class RekcurdWorkerServicerTest(unittest.TestCase):
         self.assertEqual(response.status, 0)
 
     @patch_predictor()
-    def test_EvalauteModel(self):
+    def test_EvaluateModel(self):
         request = rekcurd_pb2.EvaluateModelRequest(data_path='my_path', result_path='my_path')
         rpc = self._real_time_server.invoke_stream_unary(
             target_service.methods_by_name['EvaluateModel'], (), None)
@@ -163,6 +162,7 @@ class RekcurdWorkerServicerTest(unittest.TestCase):
         self.assertEqual([round(r, 3) for r in response.metrics.recall], eval_result.recall)
         self.assertEqual([round(f, 3) for f in response.metrics.fvalue], eval_result.fvalue)
         self.assertEqual(round(response.metrics.option['dummy'], 3), eval_result.option['dummy'])
+        self.assertEqual([l.str.val[0] for l in response.metrics.label], eval_result.label)
 
     @patch_predictor()
     def test_InvalidEvalauteModel(self):
@@ -203,6 +203,7 @@ class RekcurdWorkerServicerTest(unittest.TestCase):
         self.assertEqual([round(r, 3) for r in response.metrics.recall], eval_result.recall)
         self.assertEqual([round(f, 3) for f in response.metrics.fvalue], eval_result.fvalue)
         self.assertEqual(round(response.metrics.option['dummy'], 3), eval_result.option['dummy'])
+        self.assertEqual([l.str.val[0] for l in response.metrics.label], eval_result.label)
 
         self.assertEqual(len(response.detail), 1)
         detail = response.detail[0]

--- a/test/test_dashboard_servicer.py
+++ b/test/test_dashboard_servicer.py
@@ -12,7 +12,7 @@ from . import app, system_logger
 
 
 target_service = rekcurd_pb2.DESCRIPTOR.services_by_name['RekcurdDashboard']
-eval_result = EvaluateResult(1, 0.8, [0.7], [0.6], [0.5], {'dummy': 0.4}, ['label1'])
+eval_result = EvaluateResult(1, 0.8, [0.7], [0.6], [0.5], ['label1'], {'dummy': 0.4})
 eval_result_details = [EvaluateResultDetail(PredictResult('pre_label', 0.9), False)]
 eval_detail = EvaluateDetail('input', 'label', eval_result_details[0])
 


### PR DESCRIPTION
## What is this PR for?

added label to `EvaluationMetrics` to identify which precision, recall and fvalue correspond to which labels.

## This PR includes

- add label to `EvaluateResult` class
- pass label IO to `rekcurd_pb2.EvaluationMetrics`
- fix test

## What type of PR is it?

Feature

## What is the issue?

N/A

## How should this be tested?

`python -m unittest test.test_dashboard_servicer`
