### PR TITLE
Add `service_insecure_host` option

### DIFF
--- a/rekcurd/core/rekcurd_worker.py
+++ b/rekcurd/core/rekcurd_worker.py
@@ -110,8 +110,10 @@ class Rekcurd(metaclass=ABCMeta):
 
         if self.config is None:
             self.config = RekcurdConfig()
-        if port and "service_port" in options:
-            options["service_port"] = port
+        if host and "service_insecure_host" in options:
+            options["service_insecure_host"] = host
+        if port and "service_insecure_port" in options:
+            options["service_insecure_port"] = port
         self.config.set_configurations(**options)
 
         self.data_server = DataServer(self.config)
@@ -122,8 +124,8 @@ class Rekcurd(metaclass=ABCMeta):
         _host = "127.0.0.1"
         _port = 5000
         _max_workers = 1
-        host = host or _host
-        port = int(port or self.config.SERVICE_PORT or _port)
+        host = host or self.config.SERVICE_INSECURE_HOST or _host
+        port = int(port or self.config.SERVICE_INSECURE_PORT or _port)
         max_workers = int(max_workers or _max_workers)
 
         try:

--- a/rekcurd/template/settings.yml-tpl
+++ b/rekcurd/template/settings.yml-tpl
@@ -6,7 +6,8 @@ debug: True
 ## Application parameters.
 app:
   name: RekcurdAppTemplate          # This must be unique.
-  port: 5000                        # Service port. Default "5000"
+  host: 127.0.0.1                   # Service insecure host. Default "127.0.0.1"
+  port: 5000                        # Service insecure port. Default "5000"
   service_level: development        # Service level. One of [development/beta/staging/sandbox/production]. Default "development"
 
 ## Machine learning model access parameters.

--- a/rekcurd/utils/rekcurd_config.py
+++ b/rekcurd/utils/rekcurd_config.py
@@ -34,13 +34,15 @@ class RekcurdConfig:
     """
     Rekcurd configurations.
     """
+    __SERVICE_DEFAULT_HOST = "127.0.0.1"
     __SERVICE_DEFAULT_PORT = 5000
     __CEPH_DEFAULT_PORT = 8773
     KUBERNETES_MODE: str = None
     DEBUG_MODE: bool = None
     APPLICATION_NAME: str = None
     SERVICE_NAME: str = None
-    SERVICE_PORT: int = __SERVICE_DEFAULT_PORT
+    SERVICE_INSECURE_HOST: str = __SERVICE_DEFAULT_HOST
+    SERVICE_INSECURE_PORT: int = __SERVICE_DEFAULT_PORT
     SERVICE_LEVEL: str = None
     MODEL_MODE_ENUM: ModelModeEnum = None
     MODEL_FILE_PATH: str = None
@@ -63,8 +65,8 @@ class RekcurdConfig:
             self.__load_from_env()
 
     def set_configurations(
-            self, debug_mode: bool = None,
-            application_name: str = None, service_port: int = None,
+            self, debug_mode: bool = None, application_name: str = None,
+            service_insecure_host: str = None, service_insecure_port: int = None,
             service_level: str = None, model_mode: str = None,
             model_filepath: str = None, ceph_access_key: str = None,
             ceph_secret_key: str = None, ceph_host: str = None,
@@ -75,7 +77,8 @@ class RekcurdConfig:
         self.DEBUG_MODE = debug_mode if debug_mode is not None else self.DEBUG_MODE
         self.APPLICATION_NAME = application_name or self.APPLICATION_NAME
         self.SERVICE_NAME = self.APPLICATION_NAME
-        self.SERVICE_PORT = int(service_port or self.SERVICE_PORT)
+        self.SERVICE_INSECURE_HOST = service_insecure_host or self.SERVICE_INSECURE_HOST
+        self.SERVICE_INSECURE_PORT = int(service_insecure_port or self.SERVICE_INSECURE_PORT)
         self.SERVICE_LEVEL = service_level or self.SERVICE_LEVEL
         if model_mode is not None:
             self.MODEL_MODE_ENUM = ModelModeEnum.to_Enum(model_mode)
@@ -101,7 +104,8 @@ class RekcurdConfig:
         config_app = config.get("app", dict())
         self.APPLICATION_NAME = config_app.get("name", "sample")
         self.SERVICE_NAME = self.APPLICATION_NAME
-        self.SERVICE_PORT = config_app.get("port", self.__SERVICE_DEFAULT_PORT)
+        self.SERVICE_INSECURE_HOST = config_app.get("host", self.__SERVICE_DEFAULT_HOST)
+        self.SERVICE_INSECURE_PORT = config_app.get("port", self.__SERVICE_DEFAULT_PORT)
         self.SERVICE_LEVEL = config_app.get("service_level", "development")
         config_model = config.get("model", dict())
         model_mode = config_model.get("mode", "local")
@@ -132,7 +136,8 @@ class RekcurdConfig:
         self.DEBUG_MODE = os.getenv("REKCURD_DEBUG_MODE", "True").lower() == 'true'
         self.APPLICATION_NAME = os.getenv("REKCURD_APPLICATION_NAME")
         self.SERVICE_NAME = os.getenv("REKCURD_SERVICE_NAME")
-        self.SERVICE_PORT = int(os.getenv("REKCURD_SERVICE_PORT", "{}".format(self.__SERVICE_DEFAULT_PORT)))
+        self.SERVICE_INSECURE_HOST = os.getenv("REKCURD_SERVICE_INSECURE_HOST", self.__SERVICE_DEFAULT_HOST)
+        self.SERVICE_INSECURE_PORT = int(os.getenv("REKCURD_SERVICE_INSECURE_PORT", self.__SERVICE_DEFAULT_PORT))
         self.SERVICE_LEVEL = os.getenv("REKCURD_SERVICE_LEVEL")
         model_mode = os.getenv("REKCURD_MODEL_MODE")
         self.MODEL_MODE_ENUM = ModelModeEnum.to_Enum(model_mode)


### PR DESCRIPTION
## What is this PR for?

To access gRPC service through ingress-gateway, we need to specify host as `[::]`.
For this, we need to configure `insecure_host` by environment variables.

## This PR includes

- Add `service_insecure_host` option

## What type of PR is it?

Bugfix

## What is the issue?

N/A

## How should this be tested?

```
$ python -m unittest
```
