### PR TITLE
prevent OOM due to evaluation data

### DIFF
--- a/rekcurd/core/rekcurd_worker.py
+++ b/rekcurd/core/rekcurd_worker.py
@@ -4,7 +4,7 @@
 
 from abc import ABCMeta, abstractmethod
 from enum import Enum
-from typing import List, Tuple, Generator
+from typing import Generator
 
 from rekcurd.utils import RekcurdConfig, PredictInput, PredictResult, EvaluateResult, EvaluateDetail, EvaluateResultDetail
 from rekcurd.logger import SystemLoggerInterface, ServiceLoggerInterface, JsonSystemLogger, JsonServiceLogger
@@ -44,7 +44,7 @@ class Rekcurd(metaclass=ABCMeta):
         raise NotImplemented()
 
     @abstractmethod
-    def evaluate(self, predictor: object, filepath: str) -> Tuple[EvaluateResult, List[EvaluateResultDetail]]:
+    def evaluate(self, predictor: object, filepath: str) -> Generator[EvaluateResultDetail, None, EvaluateResult]:
         """
         evaluate
         :param predictor: Your ML predictor object. object
@@ -56,18 +56,18 @@ class Rekcurd(metaclass=ABCMeta):
             result.recall: Recall. arr[float]
             result.fvalue: F1 value. arr[float]
             result.option: Optional metrics. dict[str, float]
-        :return detail[]: Detail result of each prediction. List[EvaluateResultDetail]
+        :generate detail[]: Detail result of each prediction. List[EvaluateResultDetail]
             detail[].result: Prediction result. PredictResult
             detail[].is_correct: Prediction result is correct or not. bool
         """
         raise NotImplemented()
 
     @abstractmethod
-    def get_evaluate_detail(self, filepath: str, details: List[EvaluateResultDetail]) -> Generator[EvaluateDetail, None, None]:
+    def get_evaluate_detail(self, filepath: str, details: Generator[EvaluateResultDetail, None, None]) -> Generator[EvaluateDetail, None, None]:
         """
         get_evaluate_detail
         :param filepath: Evaluation data file path. str
-        :param details: Detail result of each prediction. List[EvaluateResultDetail]
+        :param details: Detail result of each prediction. Generator[EvaluateResultDetail, None, None]
         :return rtn: Return results. Generator[EvaluateDetail, None, None]
             rtn.input: Input data. PredictInput, one of string/bytes/arr[int]/arr[float]/arr[string]
             rtn.label: Predict label. PredictLabel, one of string/bytes/arr[int]/arr[float]/arr[string]

--- a/rekcurd/template/app.py-tpl
+++ b/rekcurd/template/app.py-tpl
@@ -4,7 +4,7 @@
 # Example is available on https://github.com/rekcurd/rekcurd-example/tree/master/python/sklearn-digits
 
 
-from typing import Tuple, List, Generator
+from typing import Generator
 
 from rekcurd import Rekcurd
 from rekcurd.utils import PredictInput, PredictResult, EvaluateResult, EvaluateDetail, EvaluateResultDetail
@@ -32,7 +32,7 @@ class RekcurdAppTemplateApp(Rekcurd):
         """
         pass
 
-    def evaluate(self, predictor: object, filepath: str) -> Tuple[EvaluateResult, List[EvaluateResultDetail]]:
+    def evaluate(self, predictor: object, filepath: str) -> Generator[EvaluateResultDetail, None, EvaluateResult]:
         """ override
         TODO: Implement "evaluate"
         :param predictor: Your ML predictor object. object
@@ -50,7 +50,7 @@ class RekcurdAppTemplateApp(Rekcurd):
         """
         pass
 
-    def get_evaluate_detail(self, filepath: str, details: List[EvaluateResultDetail]) -> Generator[EvaluateDetail, None, None]:
+    def get_evaluate_detail(self, filepath: str, details: Generator[EvaluateResultDetail, None, None]) -> Generator[EvaluateDetail, None, None]:
         """ override
         TODO: Implement "get_evaluate_detail"
         :param filepath: Evaluation data file path. str

--- a/test/core/test_dashboard_servicer.py
+++ b/test/core/test_dashboard_servicer.py
@@ -55,11 +55,15 @@ class RekcurdWorkerServicerTest(unittest.TestCase):
     """
 
     def setUp(self):
+        def gen_eval():
+            for d in eval_result_details:
+                yield d
+            return eval_result
         app.load_config_file("./test/test-settings.yml")
         app.data_server = DataServer(app.config)
         app.system_logger = JsonSystemLogger(config=app.config)
         app.service_logger = JsonServiceLogger(config=app.config)
-        app.evaluate = Mock(return_value=(eval_result, eval_result_details))
+        app.evaluate = Mock(return_value=gen_eval())
         self._real_time = grpc_testing.strict_real_time()
         self._fake_time = grpc_testing.strict_fake_time(time.time())
         servicer = RekcurdDashboardServicer(RekcurdPack(app, None))

--- a/test/data_servers/test_data_server.py
+++ b/test/data_servers/test_data_server.py
@@ -1,7 +1,7 @@
 import unittest
 
 from rekcurd.protobuf import rekcurd_pb2
-from rekcurd.utils import RekcurdConfig, ModelModeEnum
+from rekcurd.utils import RekcurdConfig, ModelModeEnum, EvaluateResultDetail, EvaluateResult, PredictResult
 from rekcurd.data_servers import DataServer
 
 from . import patch_predictor
@@ -68,12 +68,15 @@ class DataServerTest(unittest.TestCase):
             self.data_server.upload_evaluation_data(request_iterator)
 
     @patch_predictor()
-    def test_upload_evaluation_result_summary(self):
-        self.assertEqual(self.data_server.upload_evaluation_result_summary(b'hoge', "test/eval/data"), "rekcurd-eval/data_eval_res.pkl")
+    def test_upload_evaluation_result(self):
+        eval_res = EvaluateResult(1, 0.4, [0.5], [0.5], [0.5], [0.5], ['label'])
 
-    @patch_predictor()
-    def test_upload_evaluation_result_detail(self):
-        self.assertEqual(self.data_server.upload_evaluation_result_detail(b'hoge', "test/eval/data"), "rekcurd-eval/data_eval_detail.pkl")
+        def generate_eval():
+            for _ in range(2):
+                yield EvaluateResultDetail(result=PredictResult('label', 0.5),
+                                           is_correct=True)
+            return eval_res
+        self.assertEqual(self.data_server.upload_evaluation_result(generate_eval(), "test/eval/data"), eval_res)
 
     @patch_predictor()
     def test_upload_evaluation_result_invalid_path(self):


### PR DESCRIPTION
## What is this PR for?
prevent OOM with large `List[EvaluateResultDetail]` data

## This PR includes

- `evaluate` method returns generator of `EvaluateResultDetail` (and lastly return EvaluateResult)
- save EvaluateResultDetail one by one
- load EvaluateResultDetail one by one

## What type of PR is it?

Feature/Bugfix/....

## What is the issue?

fixed #25 

## How should this be tested?

python -m unittest
