### PR TITLE
quit saving evaluate result as file

### DIFF
--- a/rekcurd/core/rekcurd_dashboard_servicer.py
+++ b/rekcurd/core/rekcurd_dashboard_servicer.py
@@ -198,19 +198,10 @@ class RekcurdDashboardServicer(rekcurd_pb2_grpc.RekcurdDashboardServicer):
         data_path = request.data_path
         result_path = request.result_path
         local_data_path = self.rekcurd_pack.app.data_server.get_evaluation_data_path(data_path)
-        local_result_summary_path = self.rekcurd_pack.app.data_server.get_eval_result_summary(result_path)
         local_result_detail_path = self.rekcurd_pack.app.data_server.get_eval_result_detail(result_path)
 
-        with open(local_result_summary_path, 'rb') as f:
-            result = pickle.load(f)
-        label_ios = [self.get_io_by_type(l) for l in result.label]
-        metrics = rekcurd_pb2.EvaluationMetrics(num=result.num,
-                                                accuracy=result.accuracy,
-                                                precision=result.precision,
-                                                recall=result.recall,
-                                                fvalue=result.fvalue,
-                                                option=result.option,
-                                                label=label_ios)
+        # TODO: deprecated. remove metrics from response in the next gRPC spec
+        metrics = rekcurd_pb2.EvaluationMetrics()
 
         detail_chunks = []
         detail_chunk = []

--- a/test/core/test_dashboard_servicer.py
+++ b/test/core/test_dashboard_servicer.py
@@ -204,14 +204,6 @@ class RekcurdWorkerServicerTest(unittest.TestCase):
         rpc, responses = self.__send_eval_result(1, 1)
         response = responses[0]
 
-        self.assertEqual(round(response.metrics.num, 3), eval_result.num)
-        self.assertEqual(round(response.metrics.accuracy, 3), eval_result.accuracy)
-        self.assertEqual([round(p, 3) for p in response.metrics.precision], eval_result.precision)
-        self.assertEqual([round(r, 3) for r in response.metrics.recall], eval_result.recall)
-        self.assertEqual([round(f, 3) for f in response.metrics.fvalue], eval_result.fvalue)
-        self.assertEqual(round(response.metrics.option['dummy'], 3), eval_result.option['dummy'])
-        self.assertEqual([l.str.val[0] for l in response.metrics.label], eval_result.label)
-
         self.assertEqual(len(response.detail), 1)
         detail = response.detail[0]
         self.assertEqual(detail.input.str.val, [eval_detail.input])

--- a/test/data_servers/test_data_server.py
+++ b/test/data_servers/test_data_server.py
@@ -46,12 +46,8 @@ class DataServerTest(unittest.TestCase):
         self.assertEqual(self.data_server.get_evaluation_data_path("test/eval/data"), "rekcurd-eval/data")
 
     @patch_predictor()
-    def test_get_eval_result_summary(self):
-        self.assertEqual(self.data_server.get_eval_result_summary("test/eval/data"), "rekcurd-eval/data_eval_res.pkl")
-
-    @patch_predictor()
     def test_get_eval_result_detail(self):
-        self.assertEqual(self.data_server.get_eval_result_detail("test/eval/data"), "rekcurd-eval/data_eval_detail.pkl")
+        self.assertEqual(self.data_server.get_eval_result_detail("test/eval/detail.pkl"), "rekcurd-eval/detail.pkl")
 
     def __get_UploadEvaluationDataRequest(self, data_path: str):
         yield rekcurd_pb2.UploadEvaluationDataRequest(data_path=data_path, data=b'data')


### PR DESCRIPTION
## What is this PR for?

dashboard saves evaluation result to db (result column of evaluation_result table),
so not need to save as file

## This PR includes

- quit saving evaluate result
- remove file suffix (because only 1 file is saved in evaluation)

## What type of PR is it?

fix

## What is the issue?

#45 

## How should this be tested?

python -m unittest
